### PR TITLE
Downgrade IntelliJ version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gopalkrishnaps/intellij-android:2021.1.1-30
+FROM gopalkrishnaps/intellij-android:2020.1.1-30
 
 WORKDIR /opt
 


### PR DESCRIPTION
Android Studio doesn’t use latest InteliJ version and shouldn’t have been updated.

[The check using this version passed](https://github.com/surya-soft/Leo-Android-UI/runs/2499028911).